### PR TITLE
Fixed two issues of accessing contexts wrongly

### DIFF
--- a/Framework/Source/Ensemble/CDEPersistentStoreEnsemble.m
+++ b/Framework/Source/Ensemble/CDEPersistentStoreEnsemble.m
@@ -374,7 +374,9 @@ NSString * const CDEManagedObjectContextSaveNotificationKey = @"managedObjectCon
             }
             
             // Reset the event store
-            [eventStore.managedObjectContext reset];
+            [eventStore.managedObjectContext performBlockAndWait:^{
+                [eventStore.managedObjectContext reset];
+            }];
             
             next(error, NO);
         }];
@@ -405,7 +407,9 @@ NSString * const CDEManagedObjectContextSaveNotificationKey = @"managedObjectCon
     
     CDEAsynchronousTaskBlock completeLeechTask = ^(CDEAsynchronousTaskCallbackBlock next) {
         // Reset the event store
-        [eventStore.managedObjectContext reset];
+        [self.eventStore.managedObjectContext performBlockAndWait:^{
+            [eventStore.managedObjectContext reset];
+        }];
         
         // Deleech if a save occurred during import
         if (saveOccurredDuringImport) {


### PR DESCRIPTION
This commit fixes two issues where, under certain circumstances, "reset" is being send to the managedObjectContext from the wrong queue.
